### PR TITLE
image_table作成と関連テーブルのアソシエーション

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 
 
 ### Association
-- has_many :products
-- has_many :payment_methods
-- has_one :point
-- has_many :messages
-- has_one :residence
+- has_many :products, dependent: :destroy
+- has_many :payment_methods, dependent: :destroy
+- has_one :point, dependent: :destroy
+- has_many :messages, dependent: :destroy
+- has_one :residence, dependent: :destroy
 
 
 
@@ -69,7 +69,7 @@
 ### Association
 - belongs_to :user
 - belongs_to :brand
-- has_many :images
+- has_many :images, dependent: :destroy
 - belongs_to : category
 
 
@@ -86,7 +86,7 @@
 ## imagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|image|integer|null: false|
+|image|string|null: false|
 |product_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :product

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,3 @@
+class Image < ApplicationRecord
+  belongs_to :product
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,4 @@
 class Product < ApplicationRecord
   belongs_to :user
+  has_many :images, dependent: :destroy
 end

--- a/app/models/residence.rb
+++ b/app/models/residence.rb
@@ -1,5 +1,5 @@
 class Residence < ApplicationRecord
-  belongs_to :user, dependent: :destroy, optional: true
+  belongs_to :user, optional: true
   
   validates :destination_last_name, :destination_name, :prefectures, :municipality,
             numericality: false, format: {with: /\A[ぁ-んァ-ン一-龥]/}, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_one :residence
-  has_many :products
+  has_one :residence, dependent: :destroy
+  has_many :products, dependent: :destroy
 
   validates :nickname, :birth_date,           presence: true
   validates :last_name, :name,                presence: true, format: {with: /\A[ぁ-んァ-ン一-龥]/}

--- a/db/migrate/20200326014630_create_images.rb
+++ b/db/migrate/20200326014630_create_images.rb
@@ -1,0 +1,9 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.string :image,          null: false
+      t.references :product,    null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_073657) do
+ActiveRecord::Schema.define(version: 2020_03_26_014630) do
+
+  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "image", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_images_on_product_id"
+  end
 
   create_table "products", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -64,6 +72,7 @@ ActiveRecord::Schema.define(version: 2020_03_24_073657) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "images", "products"
   add_foreign_key "products", "users"
   add_foreign_key "residences", "users"
 end

--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#What
- imageテーブルの作成
- 関連モデルのアソシエーション
# Why
- imageファイル作成に伴い、productテーブルとの関連づけが必要なため
- dependent: :destroyの付与箇所の修正も合わせて行った。