### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :set_product, only: [:show]
+  before_action :set_product, only: [:show,:destroy]
 
   def index
     @products = Product.includes(:images).order("created_at DESC")
@@ -10,6 +10,11 @@ class ProductsController < ApplicationController
   end
 
   def new
+  end
+
+  def destroy
+    @product.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -117,7 +117,7 @@
                   購入する
           - elsif current_user && user_signed_in?
             .buy-btn-contener
-              = link_to "#",class:"no-underline" do
+              = link_to product_path(@product.id), method: :delete,class:"no-underline" do
                 %button.delete-btn{type: "submit"}
                   削除する
               = link_to "#",class:"no-underline" do


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
チーム開発に必須の機能のため

以下、削除機能のGIFになります。
https://gyazo.com/a9e0271dfc3f5b31dfcbd2c972ec34f3

投稿者にしか削除ボタンが見えなくする機能については、商品詳細表示のサーバーサイドの時点で実装済みです。