### PR TITLE
出品編集機能の実装と関連ファイルの修正

### DIFF
--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -1,7 +1,7 @@
 $(document).on('turbolinks:load', ()=> {
   let buildImg = (index, url)=> {
     let html = `
-                <div class="picture_preview">
+                <div class="picture_preview not_saved_picture">
                   <img data-index="${index}" src="${url}" width="117.5px" height="118px">
                   <div class="js-remove">削除</div>
                 </div>
@@ -10,7 +10,7 @@ $(document).on('turbolinks:load', ()=> {
   }
   let buildFileField = (index)=> {
     let html = `
-              <label class="img_upload_container" >
+              <label class="img_upload_container not_saved_uploader" >
                 <div class="js-file_group" data-index="${index}">
                   <i class="fas fa-camera product_icon"></i>
                   <input class="js-file" type="file" 
@@ -27,66 +27,82 @@ $(document).on('turbolinks:load', ()=> {
   }
  
   // ============================================================
-let fileIndex = [1,2,3,4,5,6,7,8,9,10]; 
-let countPicture = $(".saved_picture").length;
-let countUploader =  $(".img_upload_container").length;
-let lastIndex = $('.js-file_group:last').data('index');
-fileIndex.splice(0, lastIndex);
-$('.hidden-destroy').hide();
-let shippingChargeId = $("#product_shipping_charges_id").val();
-if (shippingChargeId == false){
-  $("#delivery_hidden").hide();
-}
 
+  let fileIndex =  [...Array(200).keys()].map(i => ++i);
+  let countNotSavedUploader = $("not_saved_uploader").length;
+  let countTotalUploader =  $(".img_upload_container").length;
+  let lastIndex = $('.js-file_group:last').data('index');
+  fileIndex.splice(0, lastIndex);
+  $('.hidden_destroy').hide();
+  $(".not_saved_picture:first").remove();
+  let countSavedPicture = $(".saved_picture").length;
+  let countTotalPicture = $(".picture_preview").length;
   // ============================================================
-  if (countPicture > 0) {
-  $(".still_saved_picuture").remove();
-  $(".still_saved_uploader").hide();
-  $(".still_saved_uploader:last").show();
-} else if (countPicture == 0) {
-  $(".still_saved_picuture").remove();
-  if (countUploader == 0 ) {
-    $('#previews').append(buildFileField(fileIndex[0]));
-  } else {
-  $(".img_upload_container").hide();
-  $(".img_upload_container:last").show();
-  }
-}
+  if (countSavedPicture == 0) {
+    $(".not_saved_picture").remove();
+
+    if (countTotalUploader == 0 ) {
+      $('#previews').append(buildFileField(fileIndex[0]));
+    } 
+    else {
+      $(".img_upload_container").hide();
+      $(".img_upload_container:last").show();
+    }
+  } 
+  else if (countSavedPicture > 0) {
+    $(".img_upload_container").hide();
+    $(".not_saved_picture").remove();  
+    countTotalPicture = $(".picture_preview").length;
+    if (countNotSavedUploader == 0 )  $('.img_upload_container:last').after(buildFileField(fileIndex[0]));
+
+    if ( countTotalPicture == 4 || countTotalPicture == 9 ) {
+      $(".boxsize__message").hide();
+    } 
+    else if (countTotalPicture > 9) {
+      $(".img_upload_container").hide();
+    }
+    else {
+      $(".img_upload_container:last").show()
+      $(".boxsize__message").show();
+    }
+  } 
 
   // ============================================================
   $('#image-box').on('change', '.js-file', function(e) {
     let targetIndex = $(this).parent().data('index');
     let file = e.target.files[0];
     let blobUrl = window.URL.createObjectURL(file);
-    $('.js-file_group:last').parent().addClass("hidden_uploader")
+    $('.js-file_group:last').parent().addClass("hidden_uploader");
 
     if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
       img.setAttribute('image', blobUrl);
-    } else {  
-      $('.hidden_uploader:first').before(buildImg(targetIndex, blobUrl));
-      $('#previews').append(buildFileField(fileIndex[0]));
+    }
+     else {  
+      $('.img_upload_container:first').before(buildImg(targetIndex, blobUrl));
+      $('#previews').append(buildFileField(fileIndex[targetIndex + 1]));
       fileIndex.shift();
       fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
-      let countPicture = $(".picture_preview").length;
-      if (countPicture == 4 || countPicture == 9){
-        $(".boxsize__message ").hide();
-      } else if (countPicture > 9) {
-        $(".img_upload_container:last").hide();
-      } else {
-        $(".boxsize__message ").show();
-      }
+    }
+    let countPicture = $(".picture_preview").length;
+    if (countPicture == 4 || countPicture == 9){
+      $(".boxsize__message ").hide();
+    } else if (countPicture > 9) {
+      $(".img_upload_container:last").hide();
+    } else {
+      $(".boxsize__message ").show();
     }
     $(".hidden_uploader").hide();
   });
 
   // ============================================================
   $('#image-box').on('click', '.js-remove', function() {
-    let targetIndex = $(this).parent().data('index');
-    let hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
+    let targetIndex = $(this).prev().data('index');
+    let hiddenCheck = $(`input[data-index="${targetIndex}"]`);
     if (hiddenCheck) hiddenCheck.prop('checked', true);
     $(this).parent().remove();
     $(`img[data-index="${targetIndex}"]`).remove();
-    if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
+    
+    if ($('.js-file').length == 0) $('.img_upload_container:first').before(buildFileField(fileIndex[0]));
     let countPicture = $(".picture_preview").length;
     if (countPicture == 9){
       $(".img_upload_container:last").show();
@@ -99,6 +115,10 @@ if (shippingChargeId == false){
   });
   
   // ============================================================
+  
+  let shippingChargeId = $("#product_shipping_charges_id").val();
+  if (shippingChargeId == false) $("#delivery_hidden").hide();
+  
   $('.delivery_name__title').on('change', function() {
     let shippingChargeId = $("#product_shipping_charges_id").val();
     let optionInSpan = [
@@ -116,14 +136,16 @@ if (shippingChargeId == false){
           show_option.unwrap();
         });
       };
-    } else if (shippingChargeId == 2) {
+    } 
+    else if (shippingChargeId == 2) {
       $('#delivery_hidden').show();
       if (countSpan !== 5) {
         optionInSpan.forEach( function(hide_option){
           hide_option.wrap('<span class="selector-hide"></span>');
         });
       }
-    } else {
+    }
+     else {
       $('#delivery_hidden').hide();
     };
   });

--- a/app/assets/stylesheets/products_new.scss
+++ b/app/assets/stylesheets/products_new.scss
@@ -262,17 +262,6 @@
             select{
               @include selector-design;
             }
-            svg{
-              bottom: 0;
-              margin-top: 30px;
-              pointer-events: none;
-              position: absolute;
-              right: 16px;
-              top: 0;
-              path{
-                box-sizing: border-box;
-              }
-            }
 
           }
         }
@@ -340,7 +329,6 @@
           width: 100%;
           .status_box{
             display: inline-block;
-            
             width: inherit;
             padding-top: 15px;
             width: 100%;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -137,7 +137,6 @@
           }
           .text-field-right {
             margin-top: 5px;
-            margin-left: 10px;
             width: 40%;
             height: 48px;
             padding: 10px 16px 8px;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :set_product, only: [:show,:destroy]
+  before_action :set_product, except: [:index, :new, :create]
   
   def index
     @products = Product.includes(:images).order("created_at DESC")
@@ -23,6 +23,16 @@ class ProductsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @product.update(product_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
   
   def destroy
     @product.destroy
@@ -35,8 +45,8 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(:name, :text, :size_id, :products_status_id, :shipping_charges_id, 
                                     :shipping_method_id, :delivery_area_id, :estimated_delivery_date_id, 
-                                    :bland_name_id, :selling_price,
-                                    images_attributes: [:id, :image, :_destroy ]).merge(seller_id: current_user.id )
+                                    :bland_name, :selling_price,
+                                    images_attributes: [:id, :image, :_destroy ]).merge(seller_id: current_user.id)
   end
 
   def set_product

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -3,6 +3,10 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
   process resize_to_fit: [100, 100]
+  def default_url
+    'board_placeholder.png'
+  end
+  
   # Choose what kind of storage to use for this uploader:
   if Rails.env.development?
     storage :file

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: product,class:"product_form", local: true do |f|
+= form_with model: product, class:"product_form", local: true do |f|
   .product_out
     .product_box
       .product_box__img
@@ -16,11 +16,15 @@
                   = image_tag image.image.url, data: { index: i }, width: "117.5", height: '118'
                   .js-remove 削除
             = f.fields_for :images do |image|
-              .picture_preview.still_saved_picuture
-              %label.img_upload_container.still_saved_uploader
+              - if product.persisted?
+                .hidden_destroy
+                  = image.check_box :_destroy, {data: {index: image.index}}
+              .picture_preview.not_saved_picture
+              
+              %label.img_upload_container.default_uploader
                 - if product.persisted?
-                  .js-file_group{data: {index: product.images.count}}
-                    = file_field_tag :image, name: "@product[images_attributes][#{product.images.count}][image]", class: "js-file" 
+                  .js-file_group{ data: { index: image.index } }
+                    = file_field_tag :image, name: "@product[images_attributes][#{image.index}][image]", class: "js-file" 
                     %i.fas.fa-camera.product_icon
                     = image.file_field :image, class: "js-file"
                     %br/
@@ -33,9 +37,6 @@
                     %br/
                     .boxsize__message
                       クリックしてファイルをアップロード
-              - if product.persisted?
-                .hidden-destroy
-                  = image.check_box :_destroy, {data: {index: image.index}}
         .error_message
           = product.errors.full_messages_for(:images)[0]
   .product_name
@@ -83,8 +84,6 @@
               %option{"aria-selected" => "false", :label => "チケット", :value => "1027"} チケット
               %option{"aria-selected" => "false", :label => "自動車・オートバイ", :value => "1318"} 自動車・オートバイ
               %option{"aria-selected" => "false", :label => "その他", :value => "10"} その他
-            %svg{"aria-hidden" => "true", :fill => "#888888", "fill-rule" => "evenodd", :height => "24", :viewbox => "0 0 24 24", :width => "24"}
-              %path{:d => "M12,15.66a1.73,1.73,0,0,1-1.2-.49L5.21,9.54a.7.7,0,0,1,1-1l5.62,5.62c.15.15.27.15.41,0L17.8,8.6a.71.71,0,0,1,1,0,.69.69,0,0,1,0,1l-5.57,5.58A1.71,1.71,0,0,1,12,15.66Z"}
 
         .categories
           .categories_box
@@ -103,8 +102,6 @@
               %option{"aria-selected" => "false", :label => "チケット", :value => "1027"} チケット
               %option{"aria-selected" => "false", :label => "自動車・オートバイ", :value => "1318"} 自動車・オートバイ
               %option{"aria-selected" => "false", :label => "その他", :value => "10"} その他
-            %svg{"aria-hidden" => "true", :fill => "#888888", "fill-rule" => "evenodd", :height => "24", :viewbox => "0 0 24 24", :width => "24"}
-              %path{:d => "M12,15.66a1.73,1.73,0,0,1-1.2-.49L5.21,9.54a.7.7,0,0,1,1-1l5.62,5.62c.15.15.27.15.41,0L17.8,8.6a.71.71,0,0,1,1,0,.69.69,0,0,1,0,1l-5.57,5.58A1.71,1.71,0,0,1,12,15.66Z"}
 
         .categories
           .categories_box
@@ -123,15 +120,14 @@
               %option{"aria-selected" => "false", :label => "チケット", :value => "1027"} チケット
               %option{"aria-selected" => "false", :label => "自動車・オートバイ", :value => "1318"} 自動車・オートバイ
               %option{"aria-selected" => "false", :label => "その他", :value => "10"} その他
-            %svg{"aria-hidden" => "true", :fill => "#888888", "fill-rule" => "evenodd", :height => "24", :viewbox => "0 0 24 24", :width => "24"}
-              %path{:d => "M12,15.66a1.73,1.73,0,0,1-1.2-.49L5.21,9.54a.7.7,0,0,1,1-1l5.62,5.62c.15.15.27.15.41,0L17.8,8.6a.71.71,0,0,1,1,0,.69.69,0,0,1,0,1l-5.57,5.58A1.71,1.71,0,0,1,12,15.66Z"}
+
         .state
           %b サイズ
           .required
             %b 必須
         .size
           .sizes_box
-            = f.collection_select :size_id, Size.all, :id, :name, :prompt => "選択してください"
+            = f.collection_select :size_id, Size.all, :id, :name, prompt: "選択してください"
         .error_message
           = product.errors.full_messages_for(:size_id)[0]
         .brand
@@ -148,7 +144,7 @@
             %b 必須
         .status
           .status_box
-            = f.collection_select :products_status_id, ProductsStatus.all, :id, :name, :prompt => "選択してください"
+            = f.collection_select :products_status_id, ProductsStatus.all, :id, :name, prompt: "選択してください"
         .error_message
           = product.errors.full_messages_for(:products_status_id)[0]
 
@@ -163,7 +159,7 @@
               %b 必須
           .delivery_charge
             .delivery_charge__box
-              = f.collection_select :shipping_charges_id, ShippingCharges.all, :id, :name, :prompt => "選択してください"
+              = f.collection_select :shipping_charges_id, ShippingCharges.all, :id, :name, prompt: "選択してください"
           .error_message
             = product.errors.full_messages_for(:shipping_charges_id)[0]
 
@@ -174,7 +170,7 @@
                 %b 必須
             .delivery_method
               .delivery_method__box
-                = f.collection_select :shipping_method_id, ShippingMethod.all, :id, :name, :prompt => "選択してください"
+                = f.collection_select :shipping_method_id, ShippingMethod.all, :id, :name, prompt: "選択してください"
             .error_message
               = product.errors.full_messages_for(:shipping_method_id)[0]
 
@@ -184,7 +180,7 @@
               %b 必須
           .delivery_areas
             .delivery_areas__box
-              = f.collection_select :delivery_area_id, DeliveryArea.all, :id, :name, :prompt => "選択してください"
+              = f.collection_select :delivery_area_id, DeliveryArea.all, :id, :name, prompt: "選択してください"
           .error_message
             = product.errors.full_messages_for(:delivery_area_id)[0]
          
@@ -194,7 +190,7 @@
               %b 必須
           .delivery_date
             .delivery_date__box
-              = f.collection_select :estimated_delivery_date_id, EstimatedDeliveryDate.all, :id, :name, :prompt => "選択してください"
+              = f.collection_select :estimated_delivery_date_id, EstimatedDeliveryDate.all, :id, :name, prompt: "選択してください"
           .error_message
             = product.errors.full_messages_for(:estimated_delivery_date_id)[0]
 

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,0 +1,7 @@
+.product
+  .product__head
+    .head_icon
+      = link_to root_path do
+        = image_tag "logo/logo.png"
+  .product__form
+    = render "form", { product: @product }

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -97,7 +97,7 @@
       .product-lists
         - @products.each do |product|
           .product-list
-            = link_to "/products/#{product.id}" do
+            = link_to product_path(product.id) do
               .product-list__img
                 =image_tag "#{product.images[0].image}"
                 -if product.purchase_status != "出品中­"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -32,7 +32,7 @@
           %h2.item-box__name
             = @product.name
           .item-box__body
-            = image_tag @images[0].image,id: "main-image"
+            = image_tag "#{@images[0].image}",id: "main-image"
             .img__plural
               - image_count = 1
               - if @images[1]&.image == nil
@@ -40,10 +40,10 @@
               - @images.each do |i|
                 - if image_count != 0
                   - if image_count == 1
-                    = image_tag i.image,class: "sub-image active",id: image_count
+                    = image_tag "#{i.image}",class: "sub-image active",id: image_count
                     - image_count += 1
                   - else
-                    = image_tag i.image,class: "sub-image",id: image_count
+                    = image_tag "#{i.image}",class: "sub-image",id: image_count
                     - image_count += 1
           .item-box__price
             %span
@@ -120,7 +120,7 @@
               = link_to product_path(@product.id), method: :delete,class:"no-underline" do
                 %button.delete-btn{type: "submit"}
                   削除する
-              = link_to "#",class:"no-underline" do
+              = link_to edit_product_path(@product.id),class:"no-underline" do
                 %button.edit-btn{type: "submit"}
                   編集する
         .comment__box
@@ -149,7 +149,7 @@
         =link_to "ベビー・キッズをもっと見る"
         .productlists
 = render 'layouts/footer'
-=link_to "#" do
+=link_to new_product_path do
   .purchaseBtn
     .purchaseBtn__text
       出品する

--- a/app/views/users/registrations/create_residence.html.haml
+++ b/app/views/users/registrations/create_residence.html.haml
@@ -1,5 +1,5 @@
 .header-contener
-  =link_to "root_path" do
+  =link_to root_path do
     = image_tag "logo/logo.png"
   .Group
     .Group-Bar
@@ -17,4 +17,4 @@
     .registration 登録が完了しました
     .registration-form
       .top-link
-        = link_to("トップページに戻る", root_path, {class: "link-text"})
+        = link_to "トップページに戻る", root_path, class: "link-text"


### PR DESCRIPTION
# What
- 商品出品内容の編集機能の実装
- 関連ページからのルーティングとリンクのパス指定

# Why
- 出品者のみがログイン状態で編集・削除の権限を持たせる必要があるため、そのルーティングとビューの条件分岐指定(ビューの条件分岐は商品詳細のフロント作成時に実装済のため今回は編集なし)


### ============GyazoFile=============
※キャプチャで変更が確認しやすいようにupdate後の遷移先をrender :editで指定しています。
products_controllers.rbをご確認いただけるとわかるかと思いますが、実際にはredirect_to root_pathとしています。

- 詳細ページから出品編集ページへの遷移
https://gyazo.com/c2c5656e072e6b029d1ae4af7952ad0d

- 商品情報（画像・商品名・商品画像など）を変更することができる

・画像削除後に出品した場合の保存内容の変更状況
https://gyazo.com/a13e447fb6359c874f8ecf5f515ed493

・画像追加後に出品した場合の保存内容の変更状況
https://gyazo.com/d244f2405819a44e0f710598ee483308

・画像以外の項目の変更(商品名とコメント欄)
https://gyazo.com/e48009af37b10e1386882a489512d7da

- 何も編集せずに更新をしても画像無しの商品にならない
https://gyazo.com/fd31e033fb5c504f4895fc99b10b87b4

- 投稿者だけが編集ページに遷移できるようになっている
 https://gyazo.com/d568eaf6dd1c4ddf33dca1ca1108b96c
