### PR TITLE
画像サイズの変更とリンクタグの記述変更

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-  process resize_to_fit: [100, 100]
+  #process resize_to_fit: [100, 100]
   # Choose what kind of storage to use for this uploader:
   if Rails.env.development?
     storage :file

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -32,7 +32,7 @@
           %h2.item-box__name
             = @product.name
           .item-box__body
-            = image_tag @images[0].image,id: "main-image"
+            = image_tag "#{@product.images[0].image}", id: "main-image"
             .img__plural
               - image_count = 1
               - if @images[1]&.image == nil
@@ -40,10 +40,10 @@
               - @images.each do |i|
                 - if image_count != 0
                   - if image_count == 1
-                    = image_tag i.image,class: "sub-image active",id: image_count
+                    = image_tag "#{i.image}",class: "sub-image active",id: image_count
                     - image_count += 1
                   - else
-                    = image_tag i.image,class: "sub-image",id: image_count
+                    = image_tag "#{i.image}",class: "sub-image",id: image_count
                     - image_count += 1
           .item-box__price
             %span


### PR DESCRIPTION
# What
画像ファイルのサイズ変更
イメージタグの記述の変更

# Why
ローカル環境でみたさいに画像ファイルがぼやけて表示されたためサイズ変更
以前のイメージタグだと表示ができていなかったため、記述変更
