### PR TITLE
商品詳細の配送先情報変更&レンダリングの設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery
   protected

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -13,7 +13,7 @@ class ProductsController < ApplicationController
     @size = Size.find @product.size_id
     @productsStatus = ProductsStatus.find @product.products_status_id
     @shippingCharges = ShippingCharges.find @product.shipping_charges_id
-    @shippingMethod = ShippingMethod.find @product.shipping_method_id
+    @deliveryArea = DeliveryArea.find @product.delivery_area_id
     @estimatedDeliveryDate = EstimatedDeliveryDate.find @product.estimated_delivery_date_id
     @category = @product.category
   end

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -97,7 +97,7 @@
                   %th
                     発送元の地域
                   %td
-                    =link_to @shippingMethod.name
+                    =link_to @deliveryArea.name
                 %tr
                   %th
                     発送日の目安


### PR DESCRIPTION
# What
商品詳細の配送先情報変更
マイページのログアウト後のレンダリング設定

# Why
商品詳細の配送先で表示させる情報が間違っていたため修正
マイページからログアウト後、戻るボタンを押し、プロフィールなどを閲覧しようとするとエラーになってしまう問題の解消