### PR TITLE
クレジット登録ページへの遷移時のturbolinksの無効化

### DIFF
--- a/app/views/users/credit.html.haml
+++ b/app/views/users/credit.html.haml
@@ -8,7 +8,7 @@
     .credit_area
       .credit_box
         .credit_tag
-          = link_to new_card_path do
+          = link_to new_card_path, "data-turbolinks": false do
             %button.credit_btn{:type => "submit"} <b>クレジットカードを追加する</b>
     .credit_area_bottom
       = link_to "#" do


### PR DESCRIPTION
# What
- クレジット登録ページの遷移時のturbolinksを無効化した。


# Why
- 登録ページへの遷移後に１度リロードしないと登録機能が動作しなかったため修正。